### PR TITLE
 Text for Help section (#7)

### DIFF
--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -8,3 +8,7 @@
   color: black;
   text-decoration: underline;
 }
+
+html {
+  scroll-behavior: smooth;
+}

--- a/app/views/pages/help/index.html.erb
+++ b/app/views/pages/help/index.html.erb
@@ -11,7 +11,23 @@
   <div class="row">
     <div class="small-12 medium-9 column">
       <h2><%= t("pages.help.title", org: setting['org_name']) %></h2>
-      <p><%= t("pages.help.guide", org: setting['org_name']) %></p>
+      <p>
+        <%= t("pages.help.guide",
+              community_forum_link: link_to(
+                t("pages.help.menu.debates"), "#debates",
+                class: "content-link"
+              ),
+              proposals_link: link_to(
+                t("pages.help.menu.proposals"), "#proposals",
+                class: "content-link"
+              ),
+              voting_link: link_to(
+                t("pages.help.menu.polls"), "#polls",
+                class: "content-link"
+              ),
+            ).html_safe
+        %>
+      </p>
     </div>
   </div>
 

--- a/config/locales/en/pages.yml
+++ b/config/locales/en/pages.yml
@@ -7,6 +7,7 @@ en:
     help:
       title: "%{org} is a platform for citizen participation"
       guide: "This guide explains what each of the %{org} sections are for and how they work."
+      guide: "You can contribute to the %{community_forum_link}, create %{proposals_link}, and offer support by %{voting_link}. This guide clarifies what the sections are for and how they work."
       menu:
         debates: "Community Forum"
         proposals: "Proposals"


### PR DESCRIPTION
I also added native `CSS` smooth scroll for internal linking and linked the keywords in the new text so that they scroll smoothly to their respective sections. `scroll-behavior` is supported in Firefox and Chrome (desktop, mobile) and there's no real harm in using it. If a browser doesn't support it, it just jumps to the internal hash as if the `CSS` was never added.