### PR TITLE
Add troubleshooting section

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,15 @@ Development started on [2015 July 15th](https://github.com/consul/consul/commit/
 
 ## Configuration for development and test environments
 
-**NOTE**: For more detailed instructions check the [docs](https://consul_docs.gitbooks.io/docs/)
+**NOTES**:
 
-Prerequisites: install git, Ruby 2.3.2, `bundler` gem, Node.js and PostgreSQL (>=9.4).
+* For more detailed instructions check the [docs](https://consul_docs.gitbooks.io/docs/)
+
+* If there are issues installing locally see the [troubleshooting section](doc/troubleshooting.md) for some common issues.
+
+* For help setting up a Rails environment the visit [gorails.com/setup](https://gorails.com/setup)
+
+**Prerequisites**: install git, Ruby 2.3.2, `bundler` gem, Node.js and PostgreSQL (>=9.4).
 
 ```bash
 git clone https://github.com/CodeForPortland/portlandconsul.git

--- a/doc/troubleshooting.md
+++ b/doc/troubleshooting.md
@@ -1,0 +1,75 @@
+# Troubleshooting
+
+*ActiveRecord::StatementInvalid*
+
+  * Full error:
+    ```ruby
+    ActiveRecord::StatementInvalid: PG::InsufficientPrivilege:
+        ERROR:  permission denied to create database
+    ```
+
+  * Cause:
+
+      * The rails Postgres user does not have the correct attributes in the database.
+
+  * Solution:
+
+      * Log in to Postgres
+    ```bash
+    psql
+    ```
+
+      * If when logging into Postgres you receive the error:
+    ```bash
+    psql: FATAL:  database "<user>" does not exist
+    ```
+
+      * Then login with:
+    ```bash
+    psql -d template1
+    ```
+
+      * Once logged in you can access a list of user roles with `\du`
+    ```sql
+    \du
+    ```
+
+      * This will display a table with the following columns:
+    ```
+                             List of roles
+ Role name      |              Attributes                   | Member of
+----------------+-------------------------------------------+-----------
+ user_name      |                                           | {}
+    ```
+
+      * This is stating that the user `user_name` does not have any roles specified.
+
+      * Add the Create DB attribute
+    ```sql
+    ALTER USER user_name CREATEDB;
+    ```
+
+      * Add the Superuser attribute
+    ```sql
+    ALTER ROLE user_name WITH SUPERUSER;
+    ```
+
+      * Add a password
+    ```sql
+    ALTER USER user_name WITH PASSWORD 'hu8jmn3';
+    ```
+
+      * Change the expiration date of the user's password
+    ```sql
+    ALTER USER manuel VALID UNTIL 'Jan 31 2030'; # or set date to 'infinity' to last forever.
+    ```
+
+      * Check access roles again with `\du` and then quit Postgres
+    ```sql
+    \q
+    ```
+
+  * Reference Links:
+    * Alter user [https://www.postgresql.org/docs/8.0/sql-alteruser.html](https://www.postgresql.org/docs/8.0/sql-alteruser.html)
+
+    * create user [https://www.postgresql.org/docs/8.0/app-createuser.html](https://www.postgresql.org/docs/8.0/app-createuser.html)


### PR DESCRIPTION
Updated documentation with the following:

Added troubleshooting section for setting up postgres user roles. This
is needed because postgres requires the user to have authorization to
create/alter databases.

Also added a reference link to an outside source for setting up a rails
environment.
