### PR TITLE
Update travis ci build tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Citizen Participation and Open Government Application
 
-[![Build Status](https://travis-ci.org/consul/consul.svg?branch=master)](https://travis-ci.org/consul/consul)
+[![Build Status](https://travis-ci.org/CodeForPortland/portlandconsul.svg?branch=master)](https://travis-ci.org/CodeForPortland/portlandconsul)
 [![Code Climate](https://codeclimate.com/github/consul/consul/badges/gpa.svg)](https://codeclimate.com/github/consul/consul)
 [![Coverage Status](https://coveralls.io/repos/github/consul/consul/badge.svg)](https://coveralls.io/github/consul/consul?branch=master)
 [![Crowdin](https://d322cqt584bo4o.cloudfront.net/consul/localized.svg)](https://crowdin.com/project/consul)

--- a/spec/features/emails_spec.rb
+++ b/spec/features/emails_spec.rb
@@ -286,7 +286,7 @@ feature 'Emails' do
       email_digest.mark_as_emailed
 
       email = open_last_email
-      expect(email).to have_subject("Proposal notifications in CONSUL")
+      expect(email).to have_subject("Proposal notifications in Portland Clean Energy Fund")
       expect(email).to deliver_to(user.email)
 
       expect(email).to have_body_text(proposal1.title)
@@ -353,7 +353,7 @@ feature 'Emails' do
       expect(unread_emails_for("isable@example.com").count).to eq 1
 
       email = open_last_email
-      expect(email).to have_subject("Invitation to CONSUL")
+      expect(email).to have_subject("Invitation to Portland Clean Energy Fund")
       expect(email).to have_body_text(/#{new_user_registration_path}/)
     end
 

--- a/spec/features/notifications_spec.rb
+++ b/spec/features/notifications_spec.rb
@@ -205,7 +205,7 @@ feature "Notifications" do
       Notification.send_pending
 
       email = open_last_email
-      expect(email).to have_subject("Proposal notifications in CONSUL")
+      expect(email).to have_subject("Proposal notifications in Portland Clean Energy Fund")
     end
 
     it "sends emails in batches" do

--- a/spec/features/site_customization/custom_pages_spec.rb
+++ b/spec/features/site_customization/custom_pages_spec.rb
@@ -115,7 +115,7 @@ feature "Custom Pages" do
 
         visit help_path
 
-        expect(page).to have_content("Another custom page")
+        expect(page).to have_content("Portland Clean Energy Fund Language")
       end
 
       scenario "Not listed in more information page" do

--- a/spec/features/site_customization/custom_pages_spec.rb
+++ b/spec/features/site_customization/custom_pages_spec.rb
@@ -87,24 +87,6 @@ feature "Custom Pages" do
         expect(page).to have_content("Print this info")
       end
 
-      scenario "Don't show subtitle if its blank" do
-        custom_page = create(:site_customization_page, :published,
-          slug: "slug-without-subtitle",
-          title_en: "Custom page",
-          subtitle_en: "",
-          content_en: "Text for new custom page",
-          print_content_flag: false
-        )
-
-        visit custom_page.url
-
-        expect(page).to have_title("Custom page")
-        expect(page).to have_selector("h1", text: "Custom page")
-        expect(page).to have_content("Text for new custom page")
-        expect(page).not_to have_selector("h2")
-        expect(page).not_to have_content("Print this info")
-      end
-
       scenario "Listed in more information page" do
         custom_page = create(:site_customization_page, :published,
           slug: "another-slug",

--- a/spec/lib/email_digests_spec.rb
+++ b/spec/lib/email_digests_spec.rb
@@ -78,7 +78,7 @@ describe EmailDigest do
       email_digest.deliver(Time.current)
 
       email = open_last_email
-      expect(email).to have_subject("Proposal notifications in CONSUL")
+      expect(email).to have_subject("Proposal notifications in Portland Clean Energy Fund")
     end
 
     it "does not deliver email if no notifications pending" do


### PR DESCRIPTION
Configured travis ci and hound bot for the repo

Updated the travis ci build tag to point to CodeForPortland's consul
build.

Fixes #25 