### PR TITLE
fix title margin (#26)

### DIFF
--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -486,10 +486,6 @@ header {
   padding-bottom: 0;
   padding-top: 0;
 
-  @include breakpoint(medium) {
-    padding: 0;
-  }
-
   ul {
     background: none;
     padding-right: rem-calc(15);


### PR DESCRIPTION
The title had this ```padding: 0``` property for browser windows less than half the screen width, causing the title to hug up against the edge.  Removing that property leaves the title with the appropriate margin.

Fixes #26 